### PR TITLE
Support for Gnome 3.20

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
   "description": "Update indicator for Arch Linux and GNOME Shell", 
   "name": "Arch Linux Updates Indicator",
   "shell-version": [
-    "3.18"
+    "3.18",
+    "3.20"
   ], 
   "url": "https://github.com/RaphaelRochet/arch-update", 
   "uuid": "arch-update@RaphaelRochet", 


### PR DESCRIPTION
[Gnome 3.20 was released](https://www.gnome.org/news/2016/03/gnome-3-20-released/) yesterday.
I just tested and this extension works fine under Gnome 3.20!