### PR TITLE
Add vertical scroll bar to preferences window

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -39,7 +39,7 @@ function buildPrefsWidget(){
 	// Prepare labels and controls
 	let buildable = new Gtk.Builder();
 	buildable.add_from_file( Me.dir.get_path() + '/prefs.xml' );
-	let box = buildable.get_object('vbox_built');
+	let box = buildable.get_object('scrolled_window_built');
 
 	// Bind fields to settings
 	settings.bind('boot-wait' , buildable.get_object('field_wait') , 'value' , Gio.SettingsBindFlags.DEFAULT);

--- a/prefs.xml
+++ b/prefs.xml
@@ -35,273 +35,282 @@
 	<property name="step_increment">1</property>
 </object>
 
-<object class="GtkVBox" id="vbox_built">
-	<property name="margin">10</property>
-	<property name="spacing">5</property>
+<object class="GtkScrolledWindow" id="scrolled_window_built">
+	<property name="hscrollbar-policy">never</property>
+	<property name="vscrollbar-policy">automatic</property>
 
 	<child>
-		<object class="GtkLabel">
-			<property name="label" translatable="yes">&lt;b&gt;Checking for updates&lt;/b&gt;</property>
-			<property name="use_markup">true</property>
-			<property name="hexpand">true</property>
-			<property name="halign">1</property>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkBox">
+		<object class="GtkVBox" id="vbox_built">
+			<property name="margin">10</property>
 			<property name="spacing">5</property>
+			<property name="expand">true</property>
+
 			<child>
 				<object class="GtkLabel">
-					<property name="label" translatable="yes">Time to wait before first check (seconds)</property>
+					<property name="label" translatable="yes">&lt;b&gt;Checking for updates&lt;/b&gt;</property>
+					<property name="use_markup">true</property>
 					<property name="hexpand">true</property>
 					<property name="halign">1</property>
 				</object>
 			</child>
-			<child>
-				<object class="GtkSpinButton" id="field_wait">
-					<property name="adjustment">Adjust_1</property>
-				</object>
-			</child>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkBox">
-			<property name="spacing">5</property>
-			<child>
-				<object class="GtkLabel">
-					<property name="label" translatable="yes">Interval between updates check (minutes)</property>
-					<property name="hexpand">true</property>
-					<property name="halign">1</property>
-				</object>
-			</child>
-			<child>
-				<object class="GtkSpinButton" id="field_interval">
-					<property name="adjustment">Adjust_2</property>
-				</object>
-			</child>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkBox">
-			<property name="spacing">5</property>
-			<child>
-				<object class="GtkLabel">
-					<property translatable="yes" name="label">Strip out versions numbers</property>
-					<property name="hexpand">true</property>
-					<property name="halign">1</property>
-				</object>
-			</child>
-			<child>
-				<object class="GtkSwitch" id="field_stripversions">
-					<property name="active">true</property>
-				</object>
-			</child>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkSeparator">
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkLabel">
-			<property name="label" translatable="yes">&lt;b&gt;Indicator&lt;/b&gt;</property>
-			<property name="use_markup">true</property>
-			<property name="hexpand">true</property>
-			<property name="halign">1</property>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkBox">
-			<property name="spacing">5</property>
-			<child>
-				<object class="GtkLabel">
-					<property name="label" translatable="yes">Always visible</property>
-					<property name="hexpand">true</property>
-					<property name="halign">1</property>
-				</object>
-			</child>
-			<child>
-				<object class="GtkSwitch" id="field_visible">
-					<property name="active">true</property>
-				</object>
-			</child>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkBox">
-			<property name="spacing">5</property>
-			<child>
-				<object class="GtkLabel">
-					<property name="label" translatable="yes">Show updates count on indicator</property>
-					<property name="hexpand">true</property>
-					<property name="halign">1</property>
-				</object>
-			</child>
-			<child>
-				<object class="GtkSwitch" id="field_count">
-					<property name="active">true</property>
-				</object>
-			</child>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkBox">
-			<property name="spacing">5</property>
-			<child>
-				<object class="GtkLabel">
-					<property name="label" translatable="yes"> Auto-expand updates list if count is less than this number (0 to disable)</property>
-					<property name="hexpand">true</property>
-					<property name="halign">1</property>
-				</object>
-			</child>
-			<child>
-				<object class="GtkSpinButton" id="field_autoexpandlist">
-					<property name="adjustment">Adjust_3</property>
-				</object>
-			</child>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkSeparator">
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkLabel">
-			<property name="label" translatable="yes">&lt;b&gt;Notification&lt;/b&gt;</property>
-			<property name="use_markup">true</property>
-			<property name="hexpand">true</property>
-			<property name="halign">1</property>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkBox">
-			<property name="spacing">5</property>
-			<child>
-				<object class="GtkLabel">
-					<property name="label" translatable="yes">Send a notification when new updates are available</property>
-					<property name="hexpand">true</property>
-					<property name="halign">1</property>
-				</object>
-			</child>
-			<child>
-				<object class="GtkSwitch" id="field_notify">
-					<property name="active">true</property>
-				</object>
-			</child>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkBox">
-			<property name="spacing">5</property>
-			<child>
-				<object class="GtkLabel">
-					<property translatable="yes" name="label">Use transient notifications (auto dismiss)</property>
-					<property name="hexpand">true</property>
-					<property name="halign">1</property>
-				</object>
-			</child>
-			<child>
-				<object class="GtkSwitch" id="field_transient">
-					<property name="active">true</property>
-				</object>
-			</child>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkBox">
-			<property name="spacing">5</property>
-			<child>
-				<object class="GtkLabel">
-					<property translatable="yes" name="label">How much information to show on notifications</property>
-					<property name="hexpand">true</property>
-					<property name="halign">1</property>
-				</object>
-			</child>
-			<child>
-				<object class="GtkComboBoxText" id="field_howmuch">
-					<items>
-						<item translatable="yes" id="0">Count only</item>
-						<item translatable="yes" id="1">New updates names</item>
-						<item translatable="yes" id="2">All updates names</item>
-					</items>
-				</object>
-			</child>
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkSeparator">
-		</object>
-	</child>
-
-	<child>
-		<object class="GtkExpander">
-			<property name="label" translatable="yes">&lt;b&gt;Advanced settings&lt;/b&gt;</property>
-			<property name="use_markup">true</property>
-			<property name="expanded">false</property>
 
 			<child>
-				<object class="GtkVBox">
-					<property name="spacing">10</property>
-
+				<object class="GtkBox">
+					<property name="spacing">5</property>
 					<child>
-						<object class="GtkVBox">
-							<child>
-								<object class="GtkLabel">
-									<property name="label" translatable="yes">Command to check for package updates</property>
-									<property name="hexpand">true</property>
-									<property name="halign">1</property>
-								</object>
-							</child>
-							<child>
-								<object class="GtkEntry" id="field_checkcmd">
-								</object>
-							</child>
+						<object class="GtkLabel">
+							<property name="label" translatable="yes">Time to wait before first check (seconds)</property>
+							<property name="hexpand">true</property>
+							<property name="halign">1</property>
 						</object>
 					</child>
-
 					<child>
-						<object class="GtkVBox">
-							<child>
-								<object class="GtkLabel">
-									<property name="label" translatable="yes">Command to update packages</property>
-									<property name="hexpand">true</property>
-									<property name="halign">1</property>
-								</object>
-							</child>
-							<child>
-								<object class="GtkEntry" id="field_updatecmd">
-								</object>
-							</child>
+						<object class="GtkSpinButton" id="field_wait">
+							<property name="adjustment">Adjust_1</property>
 						</object>
 					</child>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkBox">
+					<property name="spacing">5</property>
+					<child>
+						<object class="GtkLabel">
+							<property name="label" translatable="yes">Interval between updates check (minutes)</property>
+							<property name="hexpand">true</property>
+							<property name="halign">1</property>
+						</object>
+					</child>
+					<child>
+						<object class="GtkSpinButton" id="field_interval">
+							<property name="adjustment">Adjust_2</property>
+						</object>
+					</child>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkBox">
+					<property name="spacing">5</property>
+					<child>
+						<object class="GtkLabel">
+							<property translatable="yes" name="label">Strip out versions numbers</property>
+							<property name="hexpand">true</property>
+							<property name="halign">1</property>
+						</object>
+					</child>
+					<child>
+						<object class="GtkSwitch" id="field_stripversions">
+							<property name="active">true</property>
+						</object>
+					</child>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkSeparator">
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkLabel">
+					<property name="label" translatable="yes">&lt;b&gt;Indicator&lt;/b&gt;</property>
+					<property name="use_markup">true</property>
+					<property name="hexpand">true</property>
+					<property name="halign">1</property>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkBox">
+					<property name="spacing">5</property>
+					<child>
+						<object class="GtkLabel">
+							<property name="label" translatable="yes">Always visible</property>
+							<property name="hexpand">true</property>
+							<property name="halign">1</property>
+						</object>
+					</child>
+					<child>
+						<object class="GtkSwitch" id="field_visible">
+							<property name="active">true</property>
+						</object>
+					</child>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkBox">
+					<property name="spacing">5</property>
+					<child>
+						<object class="GtkLabel">
+							<property name="label" translatable="yes">Show updates count on indicator</property>
+							<property name="hexpand">true</property>
+							<property name="halign">1</property>
+						</object>
+					</child>
+					<child>
+						<object class="GtkSwitch" id="field_count">
+							<property name="active">true</property>
+						</object>
+					</child>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkBox">
+					<property name="spacing">5</property>
+					<child>
+						<object class="GtkLabel">
+							<property name="label" translatable="yes"> Auto-expand updates list if count is less than this number (0 to disable)</property>
+							<property name="hexpand">true</property>
+							<property name="halign">1</property>
+						</object>
+					</child>
+					<child>
+						<object class="GtkSpinButton" id="field_autoexpandlist">
+							<property name="adjustment">Adjust_3</property>
+						</object>
+					</child>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkSeparator">
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkLabel">
+					<property name="label" translatable="yes">&lt;b&gt;Notification&lt;/b&gt;</property>
+					<property name="use_markup">true</property>
+					<property name="hexpand">true</property>
+					<property name="halign">1</property>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkBox">
+					<property name="spacing">5</property>
+					<child>
+						<object class="GtkLabel">
+							<property name="label" translatable="yes">Send a notification when new updates are available</property>
+							<property name="hexpand">true</property>
+							<property name="halign">1</property>
+						</object>
+					</child>
+					<child>
+						<object class="GtkSwitch" id="field_notify">
+							<property name="active">true</property>
+						</object>
+					</child>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkBox">
+					<property name="spacing">5</property>
+					<child>
+						<object class="GtkLabel">
+							<property translatable="yes" name="label">Use transient notifications (auto dismiss)</property>
+							<property name="hexpand">true</property>
+							<property name="halign">1</property>
+						</object>
+					</child>
+					<child>
+						<object class="GtkSwitch" id="field_transient">
+							<property name="active">true</property>
+						</object>
+					</child>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkBox">
+					<property name="spacing">5</property>
+					<child>
+						<object class="GtkLabel">
+							<property translatable="yes" name="label">How much information to show on notifications</property>
+							<property name="hexpand">true</property>
+							<property name="halign">1</property>
+						</object>
+					</child>
+					<child>
+						<object class="GtkComboBoxText" id="field_howmuch">
+							<items>
+								<item translatable="yes" id="0">Count only</item>
+								<item translatable="yes" id="1">New updates names</item>
+								<item translatable="yes" id="2">All updates names</item>
+							</items>
+						</object>
+					</child>
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkSeparator">
+				</object>
+			</child>
+
+			<child>
+				<object class="GtkExpander">
+					<property name="label" translatable="yes">&lt;b&gt;Advanced settings&lt;/b&gt;</property>
+					<property name="use_markup">true</property>
+					<property name="expanded">false</property>
 
 					<child>
 						<object class="GtkVBox">
+							<property name="spacing">10</property>
+
 							<child>
-								<object class="GtkLabel">
-									<property name="label" translatable="yes">Pacman local directory path - To detect when new packages are installed</property>
-									<property name="hexpand">true</property>
-									<property name="halign">1</property>
+								<object class="GtkVBox">
+									<child>
+										<object class="GtkLabel">
+											<property name="label" translatable="yes">Command to check for package updates</property>
+											<property name="hexpand">true</property>
+											<property name="halign">1</property>
+										</object>
+									</child>
+									<child>
+										<object class="GtkEntry" id="field_checkcmd">
+										</object>
+									</child>
 								</object>
 							</child>
+
 							<child>
-								<object class="GtkEntry" id="field_pacmandir">
+								<object class="GtkVBox">
+									<child>
+										<object class="GtkLabel">
+											<property name="label" translatable="yes">Command to update packages</property>
+											<property name="hexpand">true</property>
+											<property name="halign">1</property>
+										</object>
+									</child>
+									<child>
+										<object class="GtkEntry" id="field_updatecmd">
+										</object>
+									</child>
 								</object>
 							</child>
+
+							<child>
+								<object class="GtkVBox">
+									<child>
+										<object class="GtkLabel">
+											<property name="label" translatable="yes">Pacman local directory path - To detect when new packages are installed</property>
+											<property name="hexpand">true</property>
+											<property name="halign">1</property>
+										</object>
+									</child>
+									<child>
+										<object class="GtkEntry" id="field_pacmandir">
+										</object>
+									</child>
+								</object>
+							</child>
+
 						</object>
 					</child>
 


### PR DESCRIPTION
On my 1366x768 display (GNOME), I can never see the bottom of the preferences windows (pacman local directory). 

So, this pull request adds a vertical scroll bar to the preferences window, and the possibility to expand this same window.