### PR TITLE
Update German strings

### DIFF
--- a/locale/de_DE/arch-update.po
+++ b/locale/de_DE/arch-update.po
@@ -44,8 +44,8 @@ msgstr[1] "%d ausstehende Aktualisierungen"
 #: extension.js:258 extension.js:263
 msgid "New Arch Linux Update"
 msgid_plural "New Arch Linux Updates"
-msgstr[0] "Neue Arch Linux Aktualisierung"
-msgstr[1] "Neue Arch Linux Aktualisierungen"
+msgstr[0] "Neue Arch-Linux-Aktualisierung"
+msgstr[1] "Neue Arch-Linux-Aktualisierungen"
 
 #: extension.js:264
 #, javascript-format
@@ -69,7 +69,7 @@ msgstr "Auf dem Laufenden :)"
 #: prefs.xml:57
 #, fuzzy
 msgid "Checking for updates"
-msgstr "<b>Überprüfe auf Aktualisierungen</b>"
+msgstr "Überprüfe auf Aktualisierungen"
 
 #: prefs.xml:81
 msgid "Time to wait before first check (seconds)"
@@ -86,7 +86,7 @@ msgstr "Versionsnummern weglassen"
 #: prefs.xml:141
 #, fuzzy
 msgid "Indicator"
-msgstr "<b>Anzeige</b>"
+msgstr "Anzeige"
 
 #: prefs.xml:156
 msgid "Always visible"
@@ -100,12 +100,13 @@ msgstr "Zeige Anzahl an Aktualisierungen"
 msgid ""
 "Auto-expand updates list if updates count is less than this number (0 to "
 "disable)"
-msgstr ""
+msgstr "Liste mit Aktualisierungen automatisch ausklappen, wenn Anzahl der "
+"Aktualisierungen geringer als diese Zahl ist (0 zum Deaktivieren)"
 
 #: prefs.xml:218
 #, fuzzy
 msgid "Notification"
-msgstr "<b>Benachrichtigung</b>"
+msgstr "Benachrichtigung"
 
 #: prefs.xml:233
 msgid "Send a notification when new updates are available"
@@ -147,13 +148,13 @@ msgstr "Kommando, um Pakete zu aktualisieren"
 #: prefs.xml:346
 msgid "Pacman local directory path - To detect when new packages are installed"
 msgstr ""
-"Lokales Pacman Verzeichnis - Wird benötigt, um festzustellen, dass neue "
+"Lokales Pacman-Verzeichnis – Wird benötigt, um festzustellen, dass neue "
 "Pakete installiert werden"
 
 #: prefs.xml:363
 #, fuzzy
 msgid "Advanced settings"
-msgstr "<b>Erweiterte Einstellungen</b>"
+msgstr "Erweiterte Einstellungen"
 
 #~ msgid "<b>Timers</b>"
 #~ msgstr "<b>Timer</b>"

--- a/locale/de_DE/arch-update.po
+++ b/locale/de_DE/arch-update.po
@@ -67,7 +67,6 @@ msgid "Up to date :)"
 msgstr "Auf dem Laufenden :)"
 
 #: prefs.xml:57
-#, fuzzy
 msgid "Checking for updates"
 msgstr "Überprüfe auf Aktualisierungen"
 
@@ -84,7 +83,6 @@ msgid "Strip out versions numbers"
 msgstr "Versionsnummern weglassen"
 
 #: prefs.xml:141
-#, fuzzy
 msgid "Indicator"
 msgstr "Anzeige"
 
@@ -104,7 +102,6 @@ msgstr "Liste mit Aktualisierungen automatisch ausklappen, wenn Anzahl der "
 "Aktualisierungen geringer als diese Zahl ist (0 zum Deaktivieren)"
 
 #: prefs.xml:218
-#, fuzzy
 msgid "Notification"
 msgstr "Benachrichtigung"
 
@@ -133,7 +130,6 @@ msgid "All updates names"
 msgstr "Namen aller Aktualisierungen"
 
 #: prefs.xml:296
-#, fuzzy
 msgid "Basic settings"
 msgstr "Einstellungen"
 
@@ -152,7 +148,6 @@ msgstr ""
 "Pakete installiert werden"
 
 #: prefs.xml:363
-#, fuzzy
 msgid "Advanced settings"
 msgstr "Erweiterte Einstellungen"
 


### PR DESCRIPTION
Added one string and fixed several strings according to German spelling rules.
Maybe one should also remove all "#, fuzzy" markers, because those strings are shown in English although all other strings are in German.