### PR TITLE
Small JS warning fix

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -239,7 +239,7 @@ const ArchUpdateIndicator = new Lang.Class({
 	_startFolderMonitor: function() {
 		if (PACMAN_DIR) {
 			this.pacman_dir = Gio.file_new_for_path(PACMAN_DIR);
-			this.monitor = this.pacman_dir.monitor_directory(0, null, null);
+			this.monitor = this.pacman_dir.monitor_directory(0, null);
 			this.monitor.connect('changed', Lang.bind(this, this._onFolderChanged));
 		}
 	},


### PR DESCRIPTION
"gnome-shell[1209]: JS WARNING: [$HOME/.local/share/gnome-shell/extensions/arch-update@RaphaelRochet/extension.js 242]: Too many arguments to method Gio.File.monitor_directory: expected 2, got 3" should now disappear from the journalctl log. No plugin instability so far.