### PR TITLE
Fix #186 issue (Inconsistent icon theme)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -168,8 +168,12 @@ class ArchUpdateIndicator extends PanelMenu.Button {
 	_getCustIcon(icon_name) {
 		// I did not find a way to lookup icon via Gio, so use Gtk
 		// I couldn't find why, but get_default is sometimes null, hence this additional test
-		if (!USE_BUILDIN_ICONS && Gtk.IconTheme.get_default()) {
-			if (Gtk.IconTheme.get_default().has_icon(icon_name)) {
+
+		if (!USE_BUILDIN_ICONS && St.Settings.get().gtk_icon_theme) {
+			let theme = new Gtk.IconTheme();
+			theme.set_custom_theme( St.Settings.get().gtk_icon_theme );
+
+			if (theme.has_icon(icon_name)) {
 				return Gio.icon_new_for_string( icon_name );
 			}
 		}


### PR DESCRIPTION
I followed the opened [issue](https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/1997) in gnome-shell repo to solve.
Finally, the icon change works properly here.