### PR TITLE
Center dropdown

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -89,7 +89,7 @@ const ArchUpdateIndicator = GObject.registerClass(
 class ArchUpdateIndicator extends Button {
 
 	_init(ext) {
-		super._init(0);
+		super._init(0.5);
 		this._extension = ext;
 		/* A process builder without i10n for reproducible processing. */
 		this.launcher = new Gio.SubprocessLauncher({


### PR DESCRIPTION
In recent Gnome versions the dropdown menus on the panel are center aligned to their button. With this change arch-update will follow this new convention.

(Sorry, screenshots are in Hungarian)

Before:
![arch_before](https://github.com/RaphaelRochet/arch-update/assets/1271737/e8ac464a-cefb-4d6e-9542-88ebde551030)

After:
![arch_after](https://github.com/RaphaelRochet/arch-update/assets/1271737/6be39f02-a2b2-4b92-b02e-14bbf5fd5c53)
