### PR TITLE
Update Brazilian Portuguese translation

### DIFF
--- a/locale/pt_BR/arch-update.po
+++ b/locale/pt_BR/arch-update.po
@@ -69,8 +69,9 @@ msgstr "Atualizado :)"
 msgid "Last checked"
 msgstr "Última verificação"
 
+# Tab label, keep this short to avoid ellipsization
 msgid "Basic settings"
-msgstr "Configs básicas"
+msgstr "Básicas"
 
 msgid "Checking for updates"
 msgstr "Verificando por atualizações"
@@ -119,7 +120,7 @@ msgid "Strip out versions numbers"
 msgstr "Retirar os números das versões"
 
 msgid "Show date/time of last check"
-msgstr ""
+msgstr "Mostra data/hora da última verificação"
 
 msgid "Notification"
 msgstr "Notificação"
@@ -139,8 +140,9 @@ msgstr "Nomes das novas atualizações"
 msgid "All updates names"
 msgstr "Nomes de todas as atualizações"
 
+# Tab label, keep this short to avoid ellipsization
 msgid "Advanced settings"
-msgstr "Configs avançadas"
+msgstr "Avançadas"
 
 msgid "Command to check for package updates"
 msgstr "Comando para verificar se há atualizações de pacotes"


### PR DESCRIPTION
After my last contribution, I've spotted two issues not fast enough. So this pull request provides:
- Translation for an untranslated string accidentally left behind
- Fix for two long strings that I abbreviated, but a screen reader user asked to do differently