### PR TITLE
Support GNOME Shell 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Update indicator for Arch Linux and GNOME Shell. Runs gnome-terminal by default, you can change in settings. \n** Note : you need to install the package pacman-contrib to use the checkupdates script. **\n  Can support AUR or other distros by changing command used to check for and apply updates.",
   "name": "Arch Linux Updates Indicator",
-  "shell-version": [ "46", "47", "48" ],
+  "shell-version": [ "46", "47", "48", "49" ],
   "url": "https://github.com/RaphaelRochet/arch-update", 
   "uuid": "arch-update@RaphaelRochet", 
   "gettext-domain": "arch-update",


### PR DESCRIPTION
Support GNOME Shell version 49 by adding "49" to supported versions. Confirmed that it works on my machine running v49.